### PR TITLE
Add example usage for device model program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+device_model

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# testing
+# Device Model Converter
+
+This repository includes a small C program, `device_model.c`, that reads a device name from standard input and prints the corresponding model using a fixed lookup table.
+
+## Build
+
+```bash
+gcc device_model.c -o device_model
+```
+
+## Run
+
+```bash
+./device_model
+```
+
+### Example
+
+Running the program and entering a known device name prints the model:
+
+```bash
+$ ./device_model
+Enter device name: iPhone10,1
+Model: iPhone 8
+```

--- a/device_model.c
+++ b/device_model.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <string.h>
+
+struct DeviceMapping {
+    const char *name;
+    const char *model;
+};
+
+static struct DeviceMapping device_map[] = {
+    {"iPhone10,1", "iPhone 8"},
+    {"iPhone13,1", "iPhone 12 mini"},
+    {"SM-G950F", "Samsung Galaxy S8"},
+    {"SM-G973F", "Samsung Galaxy S10"},
+    {"Pixel 5", "Google Pixel 5"},
+};
+
+static const int num_devices = sizeof(device_map) / sizeof(device_map[0]);
+
+int main(void) {
+    char input[100];
+
+    printf("Enter device name: ");
+    if (!fgets(input, sizeof(input), stdin)) {
+        return 1;
+    }
+
+    /* remove potential trailing newline */
+    input[strcspn(input, "\n")] = '\0';
+
+    for (int i = 0; i < num_devices; ++i) {
+        if (strcmp(device_map[i].name, input) == 0) {
+            printf("Model: %s\n", device_map[i].model);
+            return 0;
+        }
+    }
+
+    printf("Model: Unknown device\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- document sample run in README
- clarify README description for the device lookup program

## Testing
- `gcc device_model.c -o device_model`
- `printf 'SM-G973F\n' | ./device_model`


------
https://chatgpt.com/codex/tasks/task_b_68697cacb5c8832eb51293c7cd8a0101