### PR TITLE
Add macOS menu bar stock ticker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,32 @@ A basic C program demonstrating how to print "Hello, world!".
 gcc hello.c -o hello
 ./hello
 ```
+
+## macOS Menu Bar Stock/Futures Ticker
+
+A simple Python script that displays the latest price for a configured symbol in the macOS menu bar. It uses the [Moomoo OpenAPI](https://www.moomoo.com) to fetch prices.
+
+### Requirements
+
+- macOS
+- Python 3
+- [`rumps`](https://pypi.org/project/rumps/) and [`requests`](https://pypi.org/project/requests/)
+
+Install dependencies:
+
+```sh
+pip install rumps requests
+```
+
+### Usage
+
+Set the necessary environment variables and run the script:
+
+```sh
+export MOOMOO_API_TOKEN="YOUR_API_TOKEN"
+export MOOMOO_SYMBOL="AAPL"  # or any other stock/futures symbol
+python stock_menu_bar.py
+```
+
+The ticker updates every 60 seconds by default. Adjust the `REFRESH_INTERVAL` environment variable to change the refresh rate.
+

--- a/stock_menu_bar.py
+++ b/stock_menu_bar.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Simple macOS menu bar app to display stock or futures prices using the Moomoo OpenAPI."""
+
+import os
+import requests
+import rumps
+
+API_ENDPOINT = os.getenv("MOOMOO_API_ENDPOINT", "https://openapi.moomoo.com/v1/market/quote")
+API_TOKEN = os.getenv("MOOMOO_API_TOKEN", "")
+SYMBOL = os.getenv("MOOMOO_SYMBOL", "AAPL")
+REFRESH_INTERVAL = int(os.getenv("REFRESH_INTERVAL", "60"))  # seconds
+
+
+def fetch_price(symbol: str) -> str:
+    """Fetch the latest price for the given symbol from the Moomoo OpenAPI."""
+    headers = {"Authorization": f"Bearer {API_TOKEN}"} if API_TOKEN else {}
+    params = {"symbol": symbol}
+    try:
+        response = requests.get(API_ENDPOINT, headers=headers, params=params, timeout=5)
+        response.raise_for_status()
+        data = response.json()
+        # Adjust the key paths below based on the actual API response structure.
+        return str(data["data"][0]["last_price"])
+    except Exception:
+        return "N/A"
+
+
+class StockTickerApp(rumps.App):
+    """Menu bar app that periodically updates the displayed price."""
+
+    def __init__(self, symbol: str) -> None:
+        super().__init__(symbol)
+        self.symbol = symbol
+        self.menu = ["Refresh"]
+        self.timer = rumps.Timer(self.refresh, REFRESH_INTERVAL)
+        self.timer.start()
+        self.refresh(None)
+
+    def refresh(self, _):
+        price = fetch_price(self.symbol)
+        self.title = f"{self.symbol} {price}"
+
+    @rumps.clicked("Refresh")
+    def manual_refresh(self, _):
+        self.refresh(None)
+
+
+def main() -> None:
+    StockTickerApp(SYMBOL).run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python example for a macOS menu bar ticker pulling quotes from the Moomoo OpenAPI
- document setup and usage of the ticker script

## Testing
- `python -m py_compile stock_menu_bar.py`


------
https://chatgpt.com/codex/tasks/task_b_68a22d8418f4832e9258c04d511c065f